### PR TITLE
initialize env if empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: flfische <flfische@student.42heilbronn.    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/04/25 17:59:27 by flfische          #+#    #+#              #
-#    Updated: 2024/04/28 17:19:40 by flfische         ###   ########.fr        #
+#    Updated: 2024/05/01 13:02:14 by flfische         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -44,6 +44,7 @@ CFILES += ft_env_index.c \
 			ft_env_create_entry.c \
 			ft_env_remove.c \
 			ft_env_get.c \
+			ft_env_init.c \
 
 # UTILS
 CFILES += ft_strarr_cpy.c \

--- a/includes/environment.h
+++ b/includes/environment.h
@@ -6,7 +6,7 @@
 /*   By: flfische <flfische@student.42heilbronn.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/26 17:21:31 by flfische          #+#    #+#             */
-/*   Updated: 2024/04/27 13:48:01 by flfische         ###   ########.fr       */
+/*   Updated: 2024/05/01 13:01:02 by flfische         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,5 +21,6 @@ int		ft_env_change(char ***env, char *key, char *val);
 char	*ft_env_create_entry(char *key, char *val);
 int		ft_env_remove(char ***env, char *key);
 char	*ft_env_get(char **env, char *key);
+int		ft_env_init(char ***env);
 
 #endif

--- a/srcs/env/ft_env_get.c
+++ b/srcs/env/ft_env_get.c
@@ -6,7 +6,7 @@
 /*   By: flfische <flfische@student.42heilbronn.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/27 12:20:29 by flfische          #+#    #+#             */
-/*   Updated: 2024/04/27 13:47:51 by flfische         ###   ########.fr       */
+/*   Updated: 2024/05/03 10:52:34 by flfische         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,9 +34,16 @@ char	*ft_env_get(char **env, char *key)
 	temp = ft_split(entry, '=');
 	if (temp == NULL)
 		return (NULL);
-	val = temp[1];
+	if (temp[1] == NULL)
+		val = ft_strdup("");
+	else
+		val = ft_strdup(temp[1]);
+	if (val == NULL)
+		return (NULL);
+	if (temp[1] != NULL)
+		free(temp[2]);
 	free(temp[0]);
-	free(temp[2]);
+	free(temp[1]);
 	free(temp);
 	return (val);
 }

--- a/srcs/env/ft_env_init.c
+++ b/srcs/env/ft_env_init.c
@@ -6,11 +6,40 @@
 /*   By: flfische <flfische@student.42heilbronn.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/01 12:33:04 by flfische          #+#    #+#             */
-/*   Updated: 2024/05/01 14:04:36 by flfische         ###   ########.fr       */
+/*   Updated: 2024/05/03 11:02:44 by flfische         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+static int	ft_get_shlvl_nbr(char *str)
+{
+	int	shlvl;
+	int	i;
+
+	i = 0;
+	shlvl = 0;
+	if (str[i] == '\0')
+		shlvl = 1000;
+	while (str[i] != '\0')
+	{
+		if (ft_isdigit(str[i]) == 0 && !(i == 0 && str[i] == '-'))
+			return (1);
+		shlvl = shlvl * 10 + (str[i] - '0');
+		i++;
+	}
+	if (str[0] == '-')
+		return (0);
+	if (shlvl > 999)
+	{
+		ft_putstr_fd("minishell: warning: shell level (", STDERR_FILENO);
+		ft_putnbr_fd(shlvl + 1, STDERR_FILENO);
+		ft_putstr_fd(") too high, resetting to 1\n", STDERR_FILENO);
+		shlvl = 0;
+	}
+	shlvl++;
+	return (shlvl);
+}
 
 static int	ft_handle_shlvl(char ***env)
 {
@@ -22,11 +51,15 @@ static int	ft_handle_shlvl(char ***env)
 	env_shlvl = ft_env_get(*env, "SHLVL");
 	if (env_shlvl == NULL)
 		return (ft_env_add(env, "SHLVL", "1"));
-	shlvl = ft_atoi(env_shlvl) + 1;
-	new_shlvl = ft_itoa(shlvl);
+	shlvl = ft_get_shlvl_nbr(env_shlvl);
+	if (shlvl == 1000)
+		new_shlvl = ft_strdup("");
+	else
+		new_shlvl = ft_itoa(shlvl);
 	if (new_shlvl == NULL)
 		return (ft_print_error(strerror(errno), NULL, NULL), 1);
 	status = ft_env_change(env, "SHLVL", new_shlvl);
+	free(env_shlvl);
 	free(new_shlvl);
 	return (status);
 }

--- a/srcs/env/ft_env_init.c
+++ b/srcs/env/ft_env_init.c
@@ -1,0 +1,63 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_env_init.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: flfische <flfische@student.42heilbronn.    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/01 12:33:04 by flfische          #+#    #+#             */
+/*   Updated: 2024/05/01 14:04:36 by flfische         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	ft_handle_shlvl(char ***env)
+{
+	char	*env_shlvl;
+	char	*new_shlvl;
+	int		shlvl;
+	int		status;
+
+	env_shlvl = ft_env_get(*env, "SHLVL");
+	if (env_shlvl == NULL)
+		return (ft_env_add(env, "SHLVL", "1"));
+	shlvl = ft_atoi(env_shlvl) + 1;
+	new_shlvl = ft_itoa(shlvl);
+	if (new_shlvl == NULL)
+		return (ft_print_error(strerror(errno), NULL, NULL), 1);
+	status = ft_env_change(env, "SHLVL", new_shlvl);
+	free(new_shlvl);
+	return (status);
+}
+
+static int	ft_env_init_pwd(char ***env)
+{
+	char	*pwd;
+	int		status;
+
+	pwd = getcwd(NULL, 0);
+	if (pwd == NULL)
+		return (ft_print_error(strerror(errno), "pwd", NULL), 1);
+	status = ft_env_add(env, "PWD", pwd);
+	free(pwd);
+	return (status);
+}
+
+/**
+ * Initializes the environment by setting the PWD if it is not set and
+ * incrementing the SHLVL variable.
+ * @param env The environment to initialize.
+ * @return 0 on success, 1 on error.
+ */
+int	ft_env_init(char ***env)
+{
+	int	status;
+
+	status = ft_handle_shlvl(env);
+	if (status != 0)
+		return (status);
+	if (ft_env_index(*env, "PWD") == -1)
+		status = ft_env_init_pwd(env);
+	return (status);
+}

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -6,7 +6,7 @@
 /*   By: flfische <flfische@student.42heilbronn.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/25 18:00:05 by flfische          #+#    #+#             */
-/*   Updated: 2024/04/27 13:54:24 by flfische         ###   ########.fr       */
+/*   Updated: 2024/05/01 13:01:48 by flfische         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ int	main(int argc, char **argv, char **envp)
 	(void)argc;
 	(void)argv;
 	env = ft_strarr_cpy(envp);
-	if (!env)
+	if (!env || ft_env_init(&env) != 0)
 		return (1);
 	ft_env(&env);
 	ft_env_add(&env, "TEST", "42");


### PR DESCRIPTION
if you run bash with `env -i bash` you can see that some envs get initialized. 
also `SHLVL` should be increased every time the minishell is called.

bash also sets `_` by default but I could not figure out how it determines the value and did not want to hardcode "usr/bin/env" just to have something there (we don't need the `_` for our shell)
